### PR TITLE
[identifyAuth] 회원 / 비회원 구별 middleware 구현

### DIFF
--- a/app/src/apis/boards/board.ctrl.js
+++ b/app/src/apis/boards/board.ctrl.js
@@ -35,6 +35,7 @@ const process = {
   findAllByPromotionCategory: async (req, res) => {
     const board = new Board(req);
     const response = await board.findAllByPromotionCategory();
+    console.log(response);
 
     if (response.success) return res.status(200).json(response);
     return res.status(500).json(response.clientMsg);

--- a/app/src/apis/boards/board.ctrl.js
+++ b/app/src/apis/boards/board.ctrl.js
@@ -35,7 +35,6 @@ const process = {
   findAllByPromotionCategory: async (req, res) => {
     const board = new Board(req);
     const response = await board.findAllByPromotionCategory();
-    console.log(response);
 
     if (response.success) return res.status(200).json(response);
     return res.status(500).json(response.clientMsg);

--- a/app/src/apis/boards/index.js
+++ b/app/src/apis/boards/index.js
@@ -3,40 +3,72 @@
 const express = require('express');
 const boardCtrl = require('./board.ctrl');
 const commentCtrl = require('./comment.ctrl');
+const identityCheck = require('../../middlewares/identify-auth');
+const loginCheck = require('../../middlewares/login-auth');
 
 const router = express.Router();
 
-router.post('/:category', boardCtrl.process.createBoardNum);
-router.post('/:category/:boardNum', commentCtrl.process.createCommentNum);
+router.post(
+  '/:category',
+  loginCheck.loginCheck,
+  boardCtrl.process.createBoardNum
+);
+router.post(
+  '/:category/:boardNum',
+  loginCheck.loginCheck,
+  commentCtrl.process.createCommentNum
+);
 router.post(
   '/:category/:boardNum/:cmtNum',
+  loginCheck.loginCheck,
   commentCtrl.process.createReplyCommentNum
 );
 
-router.get('/:category/:sort/:order', boardCtrl.process.findAllByCategoryNum);
+router.get(
+  '/:category/:sort/:order',
+  identityCheck.identityCheck,
+  boardCtrl.process.findAllByCategoryNum
+);
 router.get(
   '/promotion/:clubCategory/:sort/:order',
+  identityCheck.identityCheck,
   boardCtrl.process.findAllByPromotionCategory
 );
-router.get('/:category/:boardNum', boardCtrl.process.findOneByBoardNum);
+router.get(
+  '/:category/:boardNum',
+  identityCheck.identityCheck,
+  boardCtrl.process.findOneByBoardNum
+);
 
-router.put('/:category/:boardNum', boardCtrl.process.updateOneByBoardNum);
+router.put(
+  '/:category/:boardNum',
+  loginCheck.loginCheck,
+  boardCtrl.process.updateOneByBoardNum
+);
 router.put(
   '/:category/:boardNum/:cmtNum',
+  loginCheck.loginCheck,
   commentCtrl.process.updateByCommentNum
 );
 router.put(
   '/:category/:boardNum/:cmtNum/:replyCmtNum',
+  loginCheck.loginCheck,
   commentCtrl.process.updateByReplyCommentNum
 );
 
-router.delete('/:category/:boardNum', boardCtrl.process.deleteOneByBoardNum);
+router.delete(
+  '/:category/:boardNum',
+  loginCheck.loginCheck,
+  boardCtrl.process.deleteOneByBoardNum
+);
 router.delete(
   '/:category/:boardNum/:cmtNum',
+  loginCheck.loginCheck,
   commentCtrl.process.deleteAllByGroupNum
 );
 router.delete(
   '/:category/:boardNum/:cmtNum/:replyCmtNum',
+  loginCheck.loginCheck,
   commentCtrl.process.deleteOneReplyCommentNum
 );
 

--- a/app/src/middlewares/identify-auth.js
+++ b/app/src/middlewares/identify-auth.js
@@ -1,0 +1,16 @@
+'use strcit';
+
+const loginCheck = require('./login-auth');
+
+const identityCheck = (req, res, next) => {
+  const token = req.headers['x-auth-token'];
+
+  // token 존재 -> 로그인 / 임의토큰
+  if (token !== undefined) {
+    loginCheck.loginCheck(req, res, next);
+  } else next();
+};
+
+module.exports = {
+  identityCheck,
+};

--- a/app/src/models/services/Board/Board.js
+++ b/app/src/models/services/Board/Board.js
@@ -8,6 +8,7 @@ class Board {
   constructor(req) {
     this.body = req.body;
     this.params = req.params;
+    this.auth = req.auth;
   }
 
   async createBoardNum() {
@@ -17,7 +18,7 @@ class Board {
       const boardInfo = {
         category,
         clubNum: 1,
-        id: request.id,
+        id: this.auth.id,
         title: request.title,
         description: request.description,
       };
@@ -56,8 +57,15 @@ class Board {
 
     try {
       const boards = await BoardStorage.findAllByCategoryNum(criteriaRead);
+      let userInfo = '비로그인 회원입니다.';
 
-      return { success: true, msg: '게시판 조회 성공', boards };
+      if (this.auth)
+        userInfo = {
+          id: this.auth.id,
+          isAdmin: this.auth.isAdmin,
+        };
+
+      return { success: true, msg: '게시판 조회 성공', userInfo, boards };
     } catch (err) {
       return Error.ctrl('서버 에러입니다. 서버 개발자에게 얘기해주세요.', err);
     }
@@ -73,8 +81,16 @@ class Board {
       const boards = await BoardStorage.findAllByPromotionCategory(
         criteriaRead
       );
+      let userInfo = '비로그인 회원입니다.';
 
-      return { success: true, msg: '장르별 조회 성공', boards };
+      if (this.auth) {
+        userInfo = {
+          id: this.auth.id,
+          club: this.auth.clubNum,
+        };
+      }
+
+      return { success: true, msg: '장르별 조회 성공', userInfo, boards };
     } catch (err) {
       return Error.ctrl('서버 에러입니다. 서버 개발자에게 얘기해주세요.', err);
     }
@@ -94,7 +110,16 @@ class Board {
           success: false,
           msg: '해당 게시판에 존재하지 않는 글 입니다.',
         };
-      return { success: true, msg: '게시글 조회 성공', board };
+
+      let userInfo = '비로그인 회원입니다.';
+
+      if (this.auth)
+        userInfo = {
+          id: this.auth.id,
+          isAdmin: this.auth.isAdmin,
+        };
+
+      return { success: true, msg: '게시글 조회 성공', userInfo, board };
     } catch (err) {
       return Error.ctrl('서버 에러입니다. 서버 개발자에게 얘기해주세요.', err);
     }

--- a/app/src/models/services/Board/Comment/Comment.js
+++ b/app/src/models/services/Board/Comment/Comment.js
@@ -8,13 +8,14 @@ class Comment {
   constructor(req) {
     this.body = req.body;
     this.params = req.params;
+    this.auth = req.auth;
   }
 
   async createCommentNum() {
     try {
       const commentInfo = {
         boardNum: this.params.boardNum,
-        id: this.body.id,
+        id: this.auth.id,
         description: this.body.description,
       };
       const exist = await BoardStorage.existOnlyBoardNum(commentInfo.boardNum);
@@ -37,7 +38,7 @@ class Comment {
       const replyCommentInfo = {
         boardNum: this.params.boardNum,
         cmtNum: this.params.cmtNum,
-        id: this.body.id,
+        id: this.auth.id,
         description: this.body.description,
       };
       const exist = await CommentStorage.existOnlyCmtNum(

--- a/app/src/models/services/Board/Comment/CommentStorage.js
+++ b/app/src/models/services/Board/Comment/CommentStorage.js
@@ -31,7 +31,7 @@ class CommentStorage {
       conn = await mariadb.getConnection();
 
       const query = `INSERT INTO comments (board_no, student_id, description, group_no, depth) VALUES (?, ?, ?, ?, 1);
-      UPDATE comments SET reply_flag = 1 WHERE no = ?;`;
+      UPDATE comments SET reply_flag = 1, modify_date = modify_date WHERE no = ?;`;
       await conn.query(query, [
         replyCommentInfo.boardNum,
         replyCommentInfo.id,
@@ -180,7 +180,7 @@ class CommentStorage {
     try {
       conn = await mariadb.getConnection();
 
-      const query = `UPDATE comments SET reply_flag = 0 WHERE no = ?;`;
+      const query = `UPDATE comments SET reply_flag = 0, modify_date = modify_date WHERE no = ?;`;
 
       const replycmt = conn.query(query, [cmtNum]);
 


### PR DESCRIPTION
1. 로그인 회원과 비로그인 회원 구별하는 middleware 작성
2. board의 index들에 middleware 추가
3. board의 body.id, body.clubNum => req.auth의 정보들로 변경
4. board 조회시 admin_flag 정보 추가
5. comment의 query문에서 modify 유지 조건 추가

#121 
#120 

## 작업내용
작업 내용

## 주의사항
주의사항 내용
