### PR TITLE
[Notification] 알림 API 수정과 알림 test 코드 분리 

### DIFF
--- a/app/src/models/services/Board/Comment/Comment.js
+++ b/app/src/models/services/Board/Comment/Comment.js
@@ -109,14 +109,10 @@ class Comment {
         user.name = '익명';
       }
 
-      const { title } = await BoardStorage.findBoardInfoByBoardNum(
-        replyCommentInfo.boardNum
-      );
-
       recipients.forEach(async (recipient) => {
         if (senderId !== recipient.id) {
           const notificationInfo = {
-            title,
+            title: recipient.description,
             senderName: user.name,
             recipientName: recipient.name,
             recipientId: recipient.id,

--- a/app/src/models/services/Board/Comment/CommentStorage.js
+++ b/app/src/models/services/Board/Comment/CommentStorage.js
@@ -255,7 +255,7 @@ class CommentStorage {
     try {
       conn = await mariadb.getConnection();
 
-      const query = `SELECT DISTINCT s.name, s.id FROM comments AS c 
+      const query = `SELECT DISTINCT s.name, s.id, c.description FROM comments AS c 
         JOIN students AS s ON c.student_id = s.id 
         WHERE c.board_no = ? AND c.group_no = ?;`;
 

--- a/app/src/models/services/Notification/NotificationStorage.js
+++ b/app/src/models/services/Notification/NotificationStorage.js
@@ -9,7 +9,7 @@ class NotificationStorage {
     try {
       conn = await mariadb.getConnection();
 
-      const query = `SELECT no, no.sender, no.url, no.notification_category_no AS notiCategoryNum, 
+      const query = `SELECT no, no.sender, no.content, no.title, no.url, no.notification_category_no AS notiCategoryNum, 
         no.in_date AS inDate FROM notifications AS no 
         WHERE no.recipient = (SELECT name FROM students WHERE id = ?) AND no.reading_flag = 0
         ORDER BY inDate DESC;`;

--- a/app/src/tests/board-notification.test.js
+++ b/app/src/tests/board-notification.test.js
@@ -11,14 +11,14 @@ const clubNotice = {
   notiCategoryNum: 6,
 };
 
-const comment = {
+const cmt = {
   description: '댓글 테스트입니다.',
   url: 'cmt/test/url',
   notiCategoryNum: 0,
   hiddenFlag: 1,
 };
 
-const reply = {
+const replyCmt = {
   description: '답글 테스트입니다.',
   url: 'reply/test/url',
   notiCategoryNum: 1,
@@ -67,7 +67,7 @@ describe('게시판 관련 알림 API 테스트', () => {
         .post('/api/club/board/clubNotice/2/26')
         .set('x-auth-token', leaderToken)
         .set('Content-Type', 'application/json')
-        .send(comment);
+        .send(cmt);
 
       expect(res.statusCode).toEqual(201);
     } catch (err) {
@@ -81,7 +81,7 @@ describe('게시판 관련 알림 API 테스트', () => {
         .post('/api/club/board/clubNotice/2/26/126')
         .set('x-auth-token', memberToken)
         .set('Content-Type', 'application/json')
-        .send(reply);
+        .send(replyCmt);
 
       expect(res.statusCode).toEqual(201);
     } catch (err) {

--- a/app/src/tests/board-notification.test.js
+++ b/app/src/tests/board-notification.test.js
@@ -1,0 +1,133 @@
+const request = require('supertest');
+const app = require('../../app');
+
+const server = request(app);
+
+const clubNotice = {
+  title: '동아리 공지 알림 생성 테스트',
+  description: '테스트테스트테스트',
+  images: [],
+  url: 'clubNotice/notification/test',
+  notiCategoryNum: 6,
+};
+
+const comment = {
+  description: '댓글 테스트입니다.',
+  url: 'cmt/test/url',
+  notiCategoryNum: 0,
+  hiddenFlag: 1,
+};
+
+const reply = {
+  description: '답글 테스트입니다.',
+  url: 'reply/test/url',
+  notiCategoryNum: 1,
+  hiddenFlag: 1,
+};
+
+const boardEmotion = {
+  url: 'emotion/notification/test',
+  notiCategoryNum: 9,
+};
+
+const cmtEmotion = {
+  url: 'emotion/notification/test',
+  notiCategoryNum: 10,
+};
+
+const replyEmotion = {
+  url: 'emotion/notification/test',
+  notiCategoryNum: 11,
+};
+
+const leaderToken =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHViTnVtIjpbMl0sImlkIjoiMjAxNzA4MDUxIiwibmFtZSI6IuuvvOyInOq4sCIsInByb2ZpbGVQYXRoIjoic2tkZmgiLCJpc0FkbWluIjoiMSIsImFsZ29yaXRobSI6IkhTMjU2IiwiaXNzdWVyIjoid29vYWhhbiBhZ2lsZSJ9.7_ZLVQVSiSEBFaZ2uKmcDMlXb22Qvi13--H3lSVio9Q';
+
+const memberToken =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHViTnVtIjpbMl0sImlkIjoiMjAxOTE2MDIyIiwibmFtZSI6Iuq5gOyngOyImCIsInByb2ZpbGVQYXRoIjoic2tkZmgiLCJpc0FkbWluIjoiMSIsImFsZ29yaXRobSI6IkhTMjU2IiwiaXNzdWVyIjoid29vYWhhbiBhZ2lsZSJ9.4A9OfY-QLvOUvZQT-TtpJ-zD2ya7k3WDblVnZ4orqCs';
+
+describe('게시판 관련 알림 API 테스트', () => {
+  it('POST 동아리 공지 글 알림생성 시 201 반환', async () => {
+    try {
+      const res = await server
+        .post('/api/club/board/clubNotice/2')
+        .set('x-auth-token', memberToken)
+        .set('Content-Type', 'application/json')
+        .send(clubNotice);
+
+      expect(res.statusCode).toEqual(201);
+    } catch (err) {
+      console.log(err);
+    }
+  });
+
+  it('POST 댓글알림 생성 시 201 반환', async () => {
+    try {
+      const res = await server
+        .post('/api/club/board/clubNotice/2/26')
+        .set('x-auth-token', leaderToken)
+        .set('Content-Type', 'application/json')
+        .send(comment);
+
+      expect(res.statusCode).toEqual(201);
+    } catch (err) {
+      console.log(err);
+    }
+  });
+
+  it('POST 답글알림 생성 시 201 반환', async () => {
+    try {
+      const res = await server
+        .post('/api/club/board/clubNotice/2/26/126')
+        .set('x-auth-token', memberToken)
+        .set('Content-Type', 'application/json')
+        .send(reply);
+
+      expect(res.statusCode).toEqual(201);
+    } catch (err) {
+      console.log(err);
+    }
+  });
+
+  it('PATCH 게시글에 좋아요 알림생성 시 200 반환', async () => {
+    try {
+      const res = await server
+        .patch('/api/emotion/liked/board/26')
+        .set('x-auth-token', leaderToken)
+        .set('Content-Type', 'application/json')
+        .send(boardEmotion);
+
+      expect(res.statusCode).toEqual(200);
+    } catch (err) {
+      console.log(err);
+    }
+  });
+
+  it('PATCH 댓글에 좋아요 알림생성 시 200 반환', async () => {
+    try {
+      const res = await server
+        .patch('/api/emotion/liked/comment/278')
+        .set('x-auth-token', memberToken)
+        .set('Content-Type', 'application/json')
+        .send(cmtEmotion);
+
+      expect(res.statusCode).toEqual(200);
+    } catch (err) {
+      console.log(err);
+    }
+  });
+
+  it('PATCH 답글에 좋아요 알림생성 시 200 반환', async () => {
+    try {
+      const res = await server
+        .patch('/api/emotion/liked/reply-comment/281')
+        .set('x-auth-token', memberToken)
+        .set('Content-Type', 'application/json')
+        .send(replyEmotion);
+
+      expect(res.statusCode).toEqual(200);
+    } catch (err) {
+      console.log(err);
+    }
+  });
+});

--- a/app/src/tests/club-notification.test.js
+++ b/app/src/tests/club-notification.test.js
@@ -53,7 +53,7 @@ const reject = {
 };
 
 const createSchedule = {
-  title: '알림생성 테스트!! 이 일정은 지우지 마세요. -김지수-',
+  title: '알림생성 테스트!!',
   colorCode: '#123456',
   startDate: '2021-11-12',
   endDate: '2021-11-12',
@@ -62,7 +62,7 @@ const createSchedule = {
 };
 
 const modifySchedule = {
-  title: '알림수정 테스트!! 이 일정은 지우지 마세요. -김지수-',
+  title: '알림수정 테스트!!',
   colorCode: '#123456',
   startDate: '2021-11-12',
   endDate: '2021-11-12',
@@ -70,15 +70,24 @@ const modifySchedule = {
   notiCategoryNum: 5,
 };
 
+const applicantToken =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHViTnVtIjpbXSwiaWQiOiIyMDAwMTAyNTUiLCJuYW1lIjoi7KeA7IiY7YWM7Iqk7Yq4IiwicHJvZmlsZVBhdGgiOiJza2RmaCIsImlzQWRtaW4iOiIxIiwiYWxnb3JpdGhtIjoiSFMyNTYiLCJpc3N1ZXIiOiJ3b29haGFuIGFnaWxlIn0.rfry4MDUAdxr_xnF0iE6Dyxe-ZyQnTL6CYU7YTtkCkM';
+
+const memberToken =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHViTnVtIjpbMl0sImlkIjoiMjAxOTE2MDIyIiwibmFtZSI6Iuq5gOyngOyImCIsInByb2ZpbGVQYXRoIjoic2tkZmgiLCJpc0FkbWluIjoiMSIsImFsZ29yaXRobSI6IkhTMjU2IiwiaXNzdWVyIjoid29vYWhhbiBhZ2lsZSJ9.4A9OfY-QLvOUvZQT-TtpJ-zD2ya7k3WDblVnZ4orqCs';
+
+const rejectToken =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHViTnVtIjpbMl0sImlkIjoiMjAwMDEwMjU1IiwibmFtZSI6IuyngOyImO2FjOyKpO2KuCIsInByb2ZpbGVQYXRoIjoic2tkZmgiLCJpc0FkbWluIjoiMSIsImFsZ29yaXRobSI6IkhTMjU2IiwiaXNzdWVyIjoid29vYWhhbiBhZ2lsZSJ9.gnPLoRHrkVCQnB3cKWJ6swDZM105GcNeCAS95tA5QOU';
+
+const leaderToken =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHViTnVtIjpbMl0sImlkIjoiMjAxNzA4MDUxIiwibmFtZSI6IuuvvOyInOq4sCIsInByb2ZpbGVQYXRoIjoic2tkZmgiLCJpc0FkbWluIjoiMSIsImFsZ29yaXRobSI6IkhTMjU2IiwiaXNzdWVyIjoid29vYWhhbiBhZ2lsZSJ9.7_ZLVQVSiSEBFaZ2uKmcDMlXb22Qvi13--H3lSVio9Q';
+
 describe('알림 API 테스트', () => {
   it('POST 동아리 가입신청 알림생성 시 201 반환', async () => {
     try {
       const res = await server
         .post('/api/club/application/2/answer')
-        .set(
-          'x-auth-token',
-          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHViTnVtIjpbXSwiaWQiOiIyMDAwMTAyNTUiLCJuYW1lIjoi7KeA7IiY7YWM7Iqk7Yq4IiwicHJvZmlsZVBhdGgiOiJza2RmaCIsImlzQWRtaW4iOiIxIiwiYWxnb3JpdGhtIjoiSFMyNTYiLCJpc3N1ZXIiOiJ3b29haGFuIGFnaWxlIn0.rfry4MDUAdxr_xnF0iE6Dyxe-ZyQnTL6CYU7YTtkCkM'
-        )
+        .set('x-auth-token', applicantToken)
         .set('Content-Type', 'application/json')
         .send(application);
 
@@ -92,10 +101,7 @@ describe('알림 API 테스트', () => {
     try {
       const res = await server
         .post('/api/club/admin-option/2/applicant')
-        .set(
-          'x-auth-token',
-          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHViTnVtIjpbMl0sImlkIjoiMjAxOTE2MDIyIiwibmFtZSI6Iuq5gOyngOyImCIsInByb2ZpbGVQYXRoIjoic2tkZmgiLCJpc0FkbWluIjoiMSIsImFsZ29yaXRobSI6IkhTMjU2IiwiaXNzdWVyIjoid29vYWhhbiBhZ2lsZSJ9.4A9OfY-QLvOUvZQT-TtpJ-zD2ya7k3WDblVnZ4orqCs'
-        )
+        .set('x-auth-token', memberToken)
         .set('Content-Type', 'application/json')
         .send(apply);
 
@@ -109,10 +115,7 @@ describe('알림 API 테스트', () => {
     try {
       const res = await server
         .put('/api/club/admin-option/2/applicant')
-        .set(
-          'x-auth-token',
-          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHViTnVtIjpbMl0sImlkIjoiMjAxOTE2MDIyIiwibmFtZSI6Iuq5gOyngOyImCIsInByb2ZpbGVQYXRoIjoic2tkZmgiLCJpc0FkbWluIjoiMSIsImFsZ29yaXRobSI6IkhTMjU2IiwiaXNzdWVyIjoid29vYWhhbiBhZ2lsZSJ9.4A9OfY-QLvOUvZQT-TtpJ-zD2ya7k3WDblVnZ4orqCs'
-        )
+        .set('x-auth-token', memberToken)
         .set('Content-Type', 'application/json')
         .send(reject);
 
@@ -126,10 +129,7 @@ describe('알림 API 테스트', () => {
     try {
       const res = await server
         .delete('/api/my-page/200010255/personal/2')
-        .set(
-          'x-auth-token',
-          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHViTnVtIjpbMl0sImlkIjoiMjAwMDEwMjU1IiwibmFtZSI6IuyngOyImO2FjOyKpO2KuCIsInByb2ZpbGVQYXRoIjoic2tkZmgiLCJpc0FkbWluIjoiMSIsImFsZ29yaXRobSI6IkhTMjU2IiwiaXNzdWVyIjoid29vYWhhbiBhZ2lsZSJ9.gnPLoRHrkVCQnB3cKWJ6swDZM105GcNeCAS95tA5QOU'
-        )
+        .set('x-auth-token', rejectToken)
         .set('Content-Type', 'application/json');
 
       expect(res.statusCode).toEqual(200);
@@ -142,10 +142,7 @@ describe('알림 API 테스트', () => {
     try {
       const res = await server
         .post('/api/club/schedule/2')
-        .set(
-          'x-auth-token',
-          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHViTnVtIjpbMl0sImlkIjoiMjAxOTE2MDIyIiwibmFtZSI6Iuq5gOyngOyImCIsInByb2ZpbGVQYXRoIjoic2tkZmgiLCJpc0FkbWluIjoiMSIsImFsZ29yaXRobSI6IkhTMjU2IiwiaXNzdWVyIjoid29vYWhhbiBhZ2lsZSJ9.4A9OfY-QLvOUvZQT-TtpJ-zD2ya7k3WDblVnZ4orqCs'
-        )
+        .set('x-auth-token', memberToken)
         .set('Content-Type', 'application/json')
         .send(modifySchedule);
 
@@ -159,10 +156,7 @@ describe('알림 API 테스트', () => {
     try {
       const res = await server
         .put('/api/club/schedule/2/1')
-        .set(
-          'x-auth-token',
-          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHViTnVtIjpbMl0sImlkIjoiMjAxOTE2MDIyIiwibmFtZSI6Iuq5gOyngOyImCIsInByb2ZpbGVQYXRoIjoic2tkZmgiLCJpc0FkbWluIjoiMSIsImFsZ29yaXRobSI6IkhTMjU2IiwiaXNzdWVyIjoid29vYWhhbiBhZ2lsZSJ9.4A9OfY-QLvOUvZQT-TtpJ-zD2ya7k3WDblVnZ4orqCs'
-        )
+        .set('x-auth-token', memberToken)
         .set('Content-Type', 'application/json')
         .send(createSchedule);
 
@@ -176,10 +170,7 @@ describe('알림 API 테스트', () => {
     try {
       const res = await server
         .patch('/api/emotion/liked/board/26')
-        .set(
-          'x-auth-token',
-          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHViTnVtIjpbMl0sImlkIjoiMjAxNzA4MDUxIiwibmFtZSI6IuuvvOyInOq4sCIsInByb2ZpbGVQYXRoIjoic2tkZmgiLCJpc0FkbWluIjoiMSIsImFsZ29yaXRobSI6IkhTMjU2IiwiaXNzdWVyIjoid29vYWhhbiBhZ2lsZSJ9.7_ZLVQVSiSEBFaZ2uKmcDMlXb22Qvi13--H3lSVio9Q'
-        )
+        .set('x-auth-token', leaderToken)
         .set('Content-Type', 'application/json')
         .send(boardEmotion);
 
@@ -193,10 +184,7 @@ describe('알림 API 테스트', () => {
     try {
       const res = await server
         .patch('/api/emotion/liked/comment/278')
-        .set(
-          'x-auth-token',
-          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHViTnVtIjpbMl0sImlkIjoiMjAxOTE2MDIyIiwibmFtZSI6Iuq5gOyngOyImCIsInByb2ZpbGVQYXRoIjoic2tkZmgiLCJpc0FkbWluIjoiMSIsImFsZ29yaXRobSI6IkhTMjU2IiwiaXNzdWVyIjoid29vYWhhbiBhZ2lsZSJ9.4A9OfY-QLvOUvZQT-TtpJ-zD2ya7k3WDblVnZ4orqCs'
-        )
+        .set('x-auth-token', memberToken)
         .set('Content-Type', 'application/json')
         .send(cmtEmotion);
 
@@ -210,10 +198,7 @@ describe('알림 API 테스트', () => {
     try {
       const res = await server
         .patch('/api/emotion/liked/reply-comment/281')
-        .set(
-          'x-auth-token',
-          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHViTnVtIjpbMl0sImlkIjoiMjAxOTE2MDIyIiwibmFtZSI6Iuq5gOyngOyImCIsInByb2ZpbGVQYXRoIjoic2tkZmgiLCJpc0FkbWluIjoiMSIsImFsZ29yaXRobSI6IkhTMjU2IiwiaXNzdWVyIjoid29vYWhhbiBhZ2lsZSJ9.4A9OfY-QLvOUvZQT-TtpJ-zD2ya7k3WDblVnZ4orqCs'
-        )
+        .set('x-auth-token', memberToken)
         .set('Content-Type', 'application/json')
         .send(replyEmotion);
 
@@ -227,10 +212,7 @@ describe('알림 API 테스트', () => {
     try {
       const res = await server
         .get('/api/notification/entire')
-        .set(
-          'x-auth-token',
-          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHViTnVtIjpbMl0sImlkIjoiMjAxOTE2MDIyIiwibmFtZSI6Iuq5gOyngOyImCIsInByb2ZpbGVQYXRoIjoic2tkZmgiLCJpc0FkbWluIjoiMSIsImFsZ29yaXRobSI6IkhTMjU2IiwiaXNzdWVyIjoid29vYWhhbiBhZ2lsZSJ9.4A9OfY-QLvOUvZQT-TtpJ-zD2ya7k3WDblVnZ4orqCs'
-        )
+        .set('x-auth-token', memberToken)
         .set('Content-Type', 'application/json');
 
       expect(res.statusCode).toEqual(200);
@@ -243,10 +225,7 @@ describe('알림 API 테스트', () => {
     try {
       const res = await server
         .patch('/api/notification/4449')
-        .set(
-          'x-auth-token',
-          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHViTnVtIjpbMl0sImlkIjoiMjAxOTE2MDIyIiwibmFtZSI6Iuq5gOyngOyImCIsInByb2ZpbGVQYXRoIjoic2tkZmgiLCJpc0FkbWluIjoiMSIsImFsZ29yaXRobSI6IkhTMjU2IiwiaXNzdWVyIjoid29vYWhhbiBhZ2lsZSJ9.4A9OfY-QLvOUvZQT-TtpJ-zD2ya7k3WDblVnZ4orqCs'
-        )
+        .set('x-auth-token', memberToken)
         .set('Content-Type', 'application/json');
 
       expect(res.statusCode).toEqual(200);
@@ -259,10 +238,7 @@ describe('알림 API 테스트', () => {
     try {
       const res = await server
         .put('/api/notification/entire')
-        .set(
-          'x-auth-token',
-          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHViTnVtIjpbMl0sImlkIjoiMjAxOTE2MDIyIiwibmFtZSI6Iuq5gOyngOyImCIsInByb2ZpbGVQYXRoIjoic2tkZmgiLCJpc0FkbWluIjoiMSIsImFsZ29yaXRobSI6IkhTMjU2IiwiaXNzdWVyIjoid29vYWhhbiBhZ2lsZSJ9.4A9OfY-QLvOUvZQT-TtpJ-zD2ya7k3WDblVnZ4orqCs'
-        )
+        .set('x-auth-token', memberToken)
         .set('Content-Type', 'application/json');
 
       expect(res.statusCode).toEqual(200);

--- a/app/src/tests/notification.test.js
+++ b/app/src/tests/notification.test.js
@@ -3,20 +3,6 @@ const app = require('../../app');
 
 const server = request(app);
 
-const comment = {
-  description: '댓글 테스트!! 이 댓글은 지우지 마세요. -김지수-',
-  url: 'test/url',
-  notiCategoryNum: 0,
-  hiddenFlag: 1,
-};
-
-const reply = {
-  description: '답글 테스트!! 이 댓글은 지우지 마세요. -김지수-',
-  url: 'test/url',
-  notiCategoryNum: 1,
-  hiddenFlag: 1,
-};
-
 const application = {
   basic: {
     grade: 1,
@@ -84,64 +70,7 @@ const modifySchedule = {
   notiCategoryNum: 5,
 };
 
-const clubNotice = {
-  title: '동아리 공지 알림 생성 테스트 !! 이 글은 지우지 마세요. -김지수-',
-  description: '동아리 공지 알림 생성 테스트',
-  images: [],
-  url: 'clubNotice/notification/test',
-  notiCategoryNum: 6,
-};
-
-const boardEmotion = {
-  url: 'emotion/notification/test',
-  notiCategoryNum: 9,
-};
-
-const cmtEmotion = {
-  url: 'emotion/notification/test',
-  notiCategoryNum: 10,
-};
-
-const replyEmotion = {
-  url: 'emotion/notification/test',
-  notiCategoryNum: 11,
-};
-
 describe('알림 API 테스트', () => {
-  it('POST 댓글알림 생성 시 201 반환', async () => {
-    try {
-      const res = await server
-        .post('/api/club/board/clubNotice/2/26')
-        .set(
-          'x-auth-token',
-          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHViTnVtIjpbMl0sImlkIjoiMjAxNzA4MDUxIiwibmFtZSI6IuuvvOyInOq4sCIsInByb2ZpbGVQYXRoIjoic2tkZmgiLCJpc0FkbWluIjoiMSIsImFsZ29yaXRobSI6IkhTMjU2IiwiaXNzdWVyIjoid29vYWhhbiBhZ2lsZSJ9.7_ZLVQVSiSEBFaZ2uKmcDMlXb22Qvi13--H3lSVio9Q'
-        )
-        .set('Content-Type', 'application/json')
-        .send(comment);
-
-      expect(res.statusCode).toEqual(201);
-    } catch (err) {
-      console.log(err);
-    }
-  });
-
-  it('POST 답글알림 생성 시 201 반환', async () => {
-    try {
-      const res = await server
-        .post('/api/club/board/clubNotice/2/26/126')
-        .set(
-          'x-auth-token',
-          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHViTnVtIjpbMl0sImlkIjoiMjAxOTE2MDIyIiwibmFtZSI6Iuq5gOyngOyImCIsInByb2ZpbGVQYXRoIjoic2tkZmgiLCJpc0FkbWluIjoiMSIsImFsZ29yaXRobSI6IkhTMjU2IiwiaXNzdWVyIjoid29vYWhhbiBhZ2lsZSJ9.4A9OfY-QLvOUvZQT-TtpJ-zD2ya7k3WDblVnZ4orqCs'
-        )
-        .set('Content-Type', 'application/json')
-        .send(reply);
-
-      expect(res.statusCode).toEqual(201);
-    } catch (err) {
-      console.log(err);
-    }
-  });
-
   it('POST 동아리 가입신청 알림생성 시 201 반환', async () => {
     try {
       const res = await server
@@ -238,23 +167,6 @@ describe('알림 API 테스트', () => {
         .send(createSchedule);
 
       expect(res.statusCode).toEqual(200);
-    } catch (err) {
-      console.log(err);
-    }
-  });
-
-  it('POST 동아리 공지 글 알림생성 시 201 반환', async () => {
-    try {
-      const res = await server
-        .post('/api/club/board/clubNotice/2')
-        .set(
-          'x-auth-token',
-          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHViTnVtIjpbMl0sImlkIjoiMjAxOTE2MDIyIiwibmFtZSI6Iuq5gOyngOyImCIsInByb2ZpbGVQYXRoIjoic2tkZmgiLCJpc0FkbWluIjoiMSIsImFsZ29yaXRobSI6IkhTMjU2IiwiaXNzdWVyIjoid29vYWhhbiBhZ2lsZSJ9.4A9OfY-QLvOUvZQT-TtpJ-zD2ya7k3WDblVnZ4orqCs'
-        )
-        .set('Content-Type', 'application/json')
-        .send(clubNotice);
-
-      expect(res.statusCode).toEqual(201);
     } catch (err) {
       console.log(err);
     }

--- a/app/src/tests/notification.test.js
+++ b/app/src/tests/notification.test.js
@@ -297,7 +297,7 @@ describe('알림 API 테스트', () => {
   it('PATCH 답글에 좋아요 알림생성 시 200 반환', async () => {
     try {
       const res = await server
-        .patch('/api/emotion/liked/reply-comment/279')
+        .patch('/api/emotion/liked/reply-comment/281')
         .set(
           'x-auth-token',
           'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHViTnVtIjpbMl0sImlkIjoiMjAxOTE2MDIyIiwibmFtZSI6Iuq5gOyngOyImCIsInByb2ZpbGVQYXRoIjoic2tkZmgiLCJpc0FkbWluIjoiMSIsImFsZ29yaXRobSI6IkhTMjU2IiwiaXNzdWVyIjoid29vYWhhbiBhZ2lsZSJ9.4A9OfY-QLvOUvZQT-TtpJ-zD2ya7k3WDblVnZ4orqCs'

--- a/app/src/tests/notification.test.js
+++ b/app/src/tests/notification.test.js
@@ -330,7 +330,7 @@ describe('알림 API 테스트', () => {
   it('PATCH 알림 삭제 시 200 반환', async () => {
     try {
       const res = await server
-        .patch('/api/notification/1571')
+        .patch('/api/notification/4449')
         .set(
           'x-auth-token',
           'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHViTnVtIjpbMl0sImlkIjoiMjAxOTE2MDIyIiwibmFtZSI6Iuq5gOyngOyImCIsInByb2ZpbGVQYXRoIjoic2tkZmgiLCJpc0FkbWluIjoiMSIsImFsZ29yaXRobSI6IkhTMjU2IiwiaXNzdWVyIjoid29vYWhhbiBhZ2lsZSJ9.4A9OfY-QLvOUvZQT-TtpJ-zD2ya7k3WDblVnZ4orqCs'


### PR DESCRIPTION
## 작업내용
- 알림 조회 시 알림의 주요 제목과 내용도 조회되도록 DB 수정
- 답글 알림 생성 시 제목을 댓글 내용이 들어가도록 수정
- 게시글 관련 알림과 동아리 관련 알림에 대해 test 코드 분리 
#117
#330 

## 주의사항
주의사항 내용
