### PR TITLE
[Notification] 게시판 알림 생성 API 수정

### DIFF
--- a/app/src/models/services/Board/Board.js
+++ b/app/src/models/services/Board/Board.js
@@ -113,6 +113,7 @@ class Board {
               recipientName: recipient.name,
               recipientId: recipient.id,
               content: boardInfo.title,
+              url: `clubhome/${clubNum}/notice/${boardNum}`,
             };
 
             await notification.createNotification(notificationInfo);

--- a/app/src/models/services/Board/Board.js
+++ b/app/src/models/services/Board/Board.js
@@ -87,6 +87,7 @@ class Board {
               recipientName: recipient.name,
               recipientId: recipient.id,
               content: boardInfo.title,
+              url: `notice/${boardNum}`,
             };
 
             await notification.createNotification(notificationInfo);

--- a/app/src/models/services/Notification/Notification.js
+++ b/app/src/models/services/Notification/Notification.js
@@ -48,7 +48,7 @@ class Notification {
         recipientName: notification.recipientName,
         recipientId: notification.recipientId,
         content: notification.content,
-        url: body.url,
+        url: body.url || notification.url,
         notiCategoryNum: body.notiCategoryNum,
       };
 


### PR DESCRIPTION
## 작업내용
- 전체 공지 게시판과 동아리별 공지게시판 알람 생성 코드 수정
- 알람 생성 시 url을 body로 받아오지 않고 저장.
- 게시글 번호를 INSERT ID로 찾아서 url 값에 추가하여 저장. 
#413 

## 주의사항
주의사항 내용
